### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -308,6 +308,8 @@ jobs:
     needs: build-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
 
     steps:
       - name: Download build artifacts


### PR DESCRIPTION
Potential fix for [https://github.com/hippieZhou/hippiezhou.github.io/security/code-scanning/7](https://github.com/hippieZhou/hippiezhou.github.io/security/code-scanning/7)

The best fix is to explicitly add a `permissions` block to the `performance-check` job (and optionally to the `build-and-test` job) to restrict the token’s capabilities, following the principle of least privilege. As `performance-check` seems only to download artifacts and run local checks, it only needs `contents: read` or potentially could set `permissions: {} (none)`. However, downloading artifacts requires read access to `contents` (or uses default), so `contents: read` is the minimal appropriate permission.

To implement this fix:
- In `.github/workflows/deploy-pages.yml`, under the `performance-check` (line 307) job definition, add a `permissions` block with `contents: read`.
- No other code changes, imports, or method definitions are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
