### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,4 +1,7 @@
 name: Dependency Check & Security Audit
+permissions:
+  contents: read
+  issues: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/hippieZhou/hippiezhou.github.io/security/code-scanning/5](https://github.com/hippieZhou/hippiezhou.github.io/security/code-scanning/5)

**How to fix:**  
Add an explicit `permissions` section to the workflow, ideally at the job (or workflow root) level. The workflow needs read access to repository contents (for checkout and reading files) and write access to issues (for programmatically creating issues about dependencies or vulnerabilities).

**Detailed fix:**  
The ideal minimal permission set is:
```yaml
permissions:
  contents: read
  issues: write
```
This should be placed at either the top level (applies to all jobs) or as part of the `dependency-check` job (within that job's block). Both are effective, but the workflow-level root is simpler and applies globally, which is desirable for single-job workflows.

**What to change:**  
In `.github/workflows/dependency-check.yml`, add the following after the `name: Dependency Check & Security Audit` line (i.e., before the `on:`). No imports or additional changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
