### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -13,6 +13,8 @@ jobs:
   # 构建和测试作业
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       NODE_VERSION: "20"
     defaults:


### PR DESCRIPTION
Potential fix for [https://github.com/hippieZhou/hippiezhou.github.io/security/code-scanning/4](https://github.com/hippieZhou/hippiezhou.github.io/security/code-scanning/4)

To address the problem, you should add an explicit `permissions` block to the `build-and-test` job in the workflow file `.github/workflows/deploy-pages.yml`. This block should minimally grant `contents: read` permissions, which are sufficient for reading repository contents during build and test phases, aligning with the principle of least privilege. Insert this block immediately below the `runs-on` key in the `build-and-test` job specification (after line 15).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
